### PR TITLE
When compilation fails, throw compiler errors as a Webpack build error

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ module.exports = function (source) {
   var compiled = solc.compile(source, optimize);
   var results = {};
 
+  if ('errors' in compiled) {
+    throw new Error(compiled.errors.join('\n'));
+  }
+
   for (var name in compiled.contracts) {
     var contract = compiled.contracts[name];
     if (compiled.contracts.hasOwnProperty(name)) {


### PR DESCRIPTION
It's really annoying when the build fails due to a contract bug, but you only notice it in the tests when you import an `undefined`. So I added these 3 lines to throw compiler errors during the build.
